### PR TITLE
Switch to `asl-help` and clean up some logic

### DIFF
--- a/BetonBrutal.asl
+++ b/BetonBrutal.asl
@@ -1,66 +1,91 @@
-state("BetonBrutal")
+state("BetonBrutal") {}
+
+startup
 {
-	int run_count : "UnityPlayer.dll", 0x01C10720, 0x8, 0x10, 0x68, 0x0, 0xA0, 0x28, 0x60;
-	int height : "UnityPlayer.dll", 0x01C18E48, 0x48, 0x828, 0x30, 0x28, 0x50, 0x88, 0x64;
-	// 1 if a Menu is on screen, 0 if player in game. used for starting along with time and height
-	int menu_active : "UnityPlayer.dll", 0x01C18E48, 0x48, 0x2B0, 0x20, 0x440, 0x18, 0x0, 0x1F0;
-	int current_time : "UnityPlayer.dll", 0x01C18E48, 0x48, 0x828, 0x30, 0x28, 0x50, 0x88, 0x7C;
+    Assembly.Load(File.ReadAllBytes("Components/asl-help")).CreateInstance("Unity");
+    vars.Helper.GameName = "Beton Brutal";
+
+    vars.Heights = new List<int>();
+
+    vars.Helper.AlertGameTime();
 }
 
+onStart
+{
+    vars.Heights.Clear();
 
-init {
-    // Read splits file and initialize internal split list
-    vars.split_file_path =  Directory.GetCurrentDirectory().ToString() + "\\BetonBrutalSplits.cfg";
-    List<int> integers = new List<int>();
-    StreamReader reader = new StreamReader(vars.split_file_path);
-    while (!reader.EndOfStream) {
-        string line = reader.ReadLine();
-        string[] tokens = line.Split(',');
-        foreach (string token in tokens) {
-            int integer = Convert.ToInt32(token.Trim());
-            integers.Add(integer);
+    using (var cfg = new StreamReader("BetonBrutalSplits.cfg"))
+    {
+        string line;
+        while ((line = cfg.ReadLine()) != null)
+        {
+            foreach (var height in line.Split(','))
+                vars.Heights.Add(Math.Abs(int.Parse(height)));
         }
     }
-    vars.split_list = integers;
-    vars.current_split = 0;
-	vars.run_ended = false;
+
+    // If user did not include 500m in their split file, add it automatically.
+    if (vars.Heights.LastOrDefault() != 500)
+        vars.Heights.Add(500);
 }
 
-start {
-    if ((old.menu_active == 1) && (current.menu_active == 0) && (current.current_time == 0) && (current.height == 0)) {
-		vars.run_ended = false;
-	    return true;
-    }
+init
+{
+    vars.Helper.TryLoad = (Func<dynamic, bool>)(mono =>
+    {
+        var gmm = mono["GameModeManager"];
+
+        vars.Helper["Runs"] = mono.Make<int>(gmm, "Instance", "stats", "numRuns");
+        vars.Helper["Height"] = mono.Make<int>(gmm, "Instance", "stats", "currentHeight");
+        vars.Helper["Time"] = mono.Make<float>(gmm, "Instance", "stats", "currentTime");
+        vars.Helper["ActiveGameMode"] = mono.Make<IntPtr>(gmm, "Instance", "ActiveGameMode");
+
+        // 0: MenuGameMode, 1: MainGameMode, 2: PracticeGameMode, 3: CustomMapGameMode, 4: MapEditorGameMode
+        vars.GameModes = vars.Helper.ReadList<IntPtr>(gmm.Static + gmm["Instance"], gmm["gameModes"]);
+
+        return true;
+    });
+}
+
+update
+{
+    current.IsOnMenu = current.ActiveGameMode == vars.GameModes[0];
+}
+
+start
+{
+    return old.IsOnMenu && !current.IsOnMenu
+        && current.Time <= 0.05 && current.Height == 0;
 }
 
 split
 {
-	if ((current.height >= 500)) {
-		vars.current_split = 0;
-		vars.run_ended = true;
-		return true;
-	}
+    // Only care about splitting when height increased.
+    if (old.Height >= current.Height)
+        return false;
 
-    if ((old.height < Math.Abs(vars.split_list[vars.current_split])) && (current.height >= Math.Abs(vars.split_list[vars.current_split]))) {
-        if (vars.split_list[vars.current_split] < 0) {
-            vars.current_split = Math.Min(vars.current_split + 1, vars.split_list.Count - 1);
-            return false;
-        }else{
-            vars.current_split = Math.Min(vars.current_split + 1, vars.split_list.Count - 1);
-            return true;
-        }
-    }
+    // Only consider the configured heights if the current split index is within the range of the list.
+    // Otherwise, only split once reaching 500m.
+    // Could result in issues if configured splits and the actual split file do not match in length.
+    var i = timer.CurrentSplitIndex;
+    return i < vars.Heights.Count && old.Height < vars.Heights[i] && current.Height >= vars.Heights[i]
+        || current.Height >= 500;
 }
 
-reset {
-    if(((old.menu_active == 0) && (current.menu_active == 1) && (vars.run_ended)) || (current.run_count > old.run_count)) {
-    	vars.current_split = 0;
-	    return true;
-    }
+reset
+{
+    // Reset when user restarts the run.
+    // Could also add a reset after the run was completed, but that does not make sense;
+    // auto splitters cannot reset the timer when timer.CurrentPhase == TimerPhase.Completed.
+    return old.Runs < current.Runs;
 }
 
-exit {
-	// With the current start logic, timer starts when game is closed. This manually resets at game close.
-	timer.CurrentPhase = TimerPhase.NotRunning;
+gameTime
+{
+    return TimeSpan.FromSeconds(current.Time);
 }
 
+isLoading
+{
+    return true;
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 This is an Auto Splitter for [Beton Brutal](https://store.steampowered.com/app/2330500/BETON_BRUTAL/). It is a [LiveSplit](https://livesplit.org/downloads/) plugin that reads the in-game memory to determine when to split/reset.
 
+**WARNING: After game updates, the memory addresses might stop working and need to manually be updated.**
 ## Setup
 
 1. Download [LiveSplit](https://livesplit.org/downloads/) and extract it somewhere (Ex:`C:\Program Files (x86)`)


### PR DESCRIPTION
This PR switches over to the use of my [`asl-help`](https://github.com/just-ero/asl-help) library for Unity games, letting us retrieve classes and their fields directly via their names, reducing the risk of breaking upon game updates. It also cleans up some of the logic in a few places.

Please go ahead and ask any questions you may have. I'm happy to elaborate on any of my decisions or enlighten you on some of the code (though please do provide line numbers).  
I have selfishly changed your formatting and naming convention. If you would like me to change back to `snake_case` or anything else, please tell me.

Other than that I should mention that this would be much better off as a component. Though this does require a hefty amount of leg work, which is almost not worth it for what you gain. It would eliminate the need for an external file for the heights, which is very inconvenient for the user and incredibly error prone. A component could simply have the heights as part of a settings control for the component itself, allowing the user to adjust when to split directly within LiveSplit. It could even generate the splits for them.

Another possibility is parsing the height directly from the split names. This way, the number of heights specified would always be the same as the amount of splits; they're directly coupled together. However, this isn't perfect either; you would be locking the users into following a specific naming scheme, removing all ability to name their segments something unique to their liking. Your call.